### PR TITLE
feat: add research-grade diary validation warnings

### DIFF
--- a/e2e/research-validation.spec.js
+++ b/e2e/research-validation.spec.js
@@ -1,0 +1,804 @@
+// @ts-check
+import { test, expect } from '@playwright/test';
+import { waitForAppReady } from './test-helpers.js';
+
+/**
+ * Test Suite: Research-grade validation warnings
+ *
+ * Tests both the validation logic (research-validation.js) and the
+ * warnings UI modal (validation-warnings-ui.js) against CTUR/HETUS
+ * data quality standards.
+ *
+ * Strategy: inject mock activity arrays via page.evaluate() and
+ * dynamically import the ES modules to exercise them in the real
+ * browser environment.
+ */
+
+// ---------------------------------------------------------------------------
+// Shared mock-data factories
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal activity object matching the timelineManager data model.
+ * @param {Partial<{id:string, activity:string, category:string, startMinutes:number, endMinutes:number, color:string}>} overrides
+ */
+function makeActivity(overrides = {}) {
+  const start = overrides.startMinutes ?? 240;
+  const end = overrides.endMinutes ?? start + 10;
+  return {
+    id: overrides.id ?? `test-${Math.random().toString(36).slice(2, 8)}`,
+    activity: overrides.activity ?? 'Sleeping',
+    category: overrides.category ?? 'Personal',
+    startTime: minutesToHHMM(start),
+    endTime: minutesToHHMM(end),
+    startMinutes: start,
+    endMinutes: end,
+    color: overrides.color ?? '#a2b4ee',
+  };
+}
+
+function minutesToHHMM(mins) {
+  const h = String(Math.floor(mins / 60) % 24).padStart(2, '0');
+  const m = String(mins % 60).padStart(2, '0');
+  return `${h}:${m}`;
+}
+
+/**
+ * Good-quality diary — 8 distinct episodes across all 4 domains.
+ * Should produce zero warnings.
+ */
+function goodDiary() {
+  return [
+    makeActivity({ activity: 'Sleeping',                               startMinutes: 240,  endMinutes: 720 }),
+    makeActivity({ activity: 'Washing, Dressing',                      startMinutes: 720,  endMinutes: 750 }),
+    makeActivity({ activity: 'Eating, Drinking, Meal (At Home or Work)', startMinutes: 750, endMinutes: 780 }),
+    makeActivity({ activity: 'Travelling: in own car',                 startMinutes: 780,  endMinutes: 810 }),
+    makeActivity({ activity: 'Paid Work (Including at Home)',          startMinutes: 810,  endMinutes: 1080 }),
+    makeActivity({ activity: 'Travelling: in own car',                 startMinutes: 1080, endMinutes: 1110 }),
+    makeActivity({ activity: 'Watching TV/DVD, Listening to Music',    startMinutes: 1110, endMinutes: 1290 }),
+    makeActivity({ activity: 'Sleeping',                               startMinutes: 1290, endMinutes: 1440 }),
+  ];
+}
+
+/**
+ * Low-episode diary — only 3 distinct activities (below MIN_EPISODES=7).
+ * Covers sleep + eating + travel but missing personal care (only 1 missing → no MISSING_DOMAINS).
+ */
+function lowEpisodeDiary() {
+  return [
+    makeActivity({ activity: 'Sleeping',                               startMinutes: 240,  endMinutes: 720 }),
+    makeActivity({ activity: 'Eating, Drinking, Meal (At Home or Work)', startMinutes: 720, endMinutes: 780 }),
+    makeActivity({ activity: 'Travelling: cycle',                      startMinutes: 780,  endMinutes: 810 }),
+  ];
+}
+
+/**
+ * Missing-domains diary — no travel, no personal care (2 missing → triggers warning).
+ * Also only 4 episodes so triggers LOW_EPISODE_COUNT too.
+ */
+function missingDomainsDiary() {
+  return [
+    makeActivity({ activity: 'Sleeping',                               startMinutes: 240,  endMinutes: 720 }),
+    makeActivity({ activity: 'Eating, Drinking, Meal (At Home or Work)', startMinutes: 720, endMinutes: 780 }),
+    makeActivity({ activity: 'Paid Work (Including at Home)',          startMinutes: 780,  endMinutes: 1080 }),
+    makeActivity({ activity: 'Watching TV/DVD, Listening to Music',    startMinutes: 1080, endMinutes: 1290 }),
+  ];
+}
+
+/**
+ * Long-activity diary — "Watching TV" for 4 hours (>180 min, not exempt).
+ * Also has 7+ episodes to avoid LOW_EPISODE_COUNT, all 4 domains covered.
+ */
+function longActivityDiary() {
+  return [
+    makeActivity({ activity: 'Sleeping',                               startMinutes: 240,  endMinutes: 720 }),
+    makeActivity({ activity: 'Washing, Dressing',                      startMinutes: 720,  endMinutes: 750 }),
+    makeActivity({ activity: 'Eating, Drinking, Meal (At Home or Work)', startMinutes: 750, endMinutes: 780 }),
+    makeActivity({ activity: 'Travelling: in own car',                 startMinutes: 780,  endMinutes: 810 }),
+    makeActivity({ activity: 'Paid Work (Including at Home)',          startMinutes: 810,  endMinutes: 1080 }),
+    makeActivity({ activity: 'Travelling: in own car',                 startMinutes: 1080, endMinutes: 1110 }),
+    makeActivity({ id: 'long-tv', activity: 'Watching TV/DVD, Listening to Music', startMinutes: 1110, endMinutes: 1350 }),
+    makeActivity({ activity: 'Sleeping',                               startMinutes: 1350, endMinutes: 1440 }),
+  ];
+}
+
+/**
+ * Consecutive-identical diary — 10 adjacent 10-min "Reading" blocks (>= 8 threshold).
+ * Also has 7+ distinct episodes and all 4 domains to isolate the consecutive warning.
+ */
+function consecutiveDiary() {
+  const readingBlocks = Array.from({ length: 10 }, (_, i) =>
+    makeActivity({
+      activity: 'Reading (Including E-books)',
+      startMinutes: 900 + i * 10,
+      endMinutes: 910 + i * 10,
+    })
+  );
+  return [
+    makeActivity({ activity: 'Sleeping',                               startMinutes: 240,  endMinutes: 720 }),
+    makeActivity({ activity: 'Washing, Dressing',                      startMinutes: 720,  endMinutes: 750 }),
+    makeActivity({ activity: 'Eating, Drinking, Meal (At Home or Work)', startMinutes: 750, endMinutes: 780 }),
+    makeActivity({ activity: 'Travelling: in own car',                 startMinutes: 780,  endMinutes: 810 }),
+    makeActivity({ activity: 'Paid Work (Including at Home)',          startMinutes: 810,  endMinutes: 900 }),
+    ...readingBlocks,
+    makeActivity({ activity: 'Sleeping',                               startMinutes: 1000, endMinutes: 1440 }),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Helper: dynamically import the validation UI module inside the page
+// ---------------------------------------------------------------------------
+
+/**
+ * Wait for page JS environment to be ready (lighter than waitForAppReady).
+ * UI tests only need the page loaded + ES module imports working; they don't
+ * need #activitiesContainer to be visible (it can be behind a PID modal).
+ *
+ * Includes a pid parameter to prevent the app from generating one and
+ * navigating mid-test, and waits for network to settle.
+ */
+const UI_TEST_URL = '/?instructions=completed&pid=e2e-test';
+
+async function waitForPageReady(page) {
+  await page.waitForLoadState('networkidle');
+  await page.waitForFunction(() => window.timelineManager !== undefined, { timeout: 15000 });
+}
+
+/**
+ * Call showValidationWarnings inside the page and return the promise handle.
+ * The returned promise is NOT awaited here — the test interacts with the
+ * modal DOM and the promise settles once the user clicks submit/review.
+ */
+async function openValidationModal(page, activities) {
+  await page.evaluate((acts) => {
+    // Store on window so the module import can access it
+    window.__testActivities = acts;
+  }, activities);
+
+  // Fire-and-forget: the modal will appear in the DOM
+  page.evaluate(async () => {
+    const { showValidationWarnings } = await import('./js/validation-warnings-ui.js');
+    window.__validationResult = showValidationWarnings(window.__testActivities);
+  });
+
+  // Wait for the overlay and at least one warning item to appear
+  await page.waitForSelector('.validation-overlay', { timeout: 5000 });
+  await page.waitForSelector('.validation-modal', { state: 'visible', timeout: 5000 });
+}
+
+/** Retrieve the resolved value of the validation promise. */
+async function getValidationResult(page) {
+  return page.evaluate(() => window.__validationResult);
+}
+
+// ============================================================================
+// Test suites
+// ============================================================================
+
+test.describe('Research Validation — Logic (validateDiaryQuality)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/?instructions=completed');
+    await waitForAppReady(page);
+  });
+
+  test('good diary produces no warnings and score of 100', async ({ page }) => {
+    const result = await page.evaluate(async (activities) => {
+      const { validateDiaryQuality } = await import('./js/research-validation.js');
+      return validateDiaryQuality(activities);
+    }, goodDiary());
+
+    expect(result.warnings).toHaveLength(0);
+    expect(result.score).toBe(100);
+    expect(result.passed).toBe(true);
+    expect(result.episodeCount).toBeGreaterThanOrEqual(7);
+    expect(result.domainCoverage.missing).toHaveLength(0);
+  });
+
+  test('empty array returns EMPTY_DIARY warning', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const { validateDiaryQuality } = await import('./js/research-validation.js');
+      return validateDiaryQuality([]);
+    });
+
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].type).toBe('EMPTY_DIARY');
+    expect(result.score).toBe(0);
+    expect(result.passed).toBe(false);
+  });
+
+  test('null input returns EMPTY_DIARY warning', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const { validateDiaryQuality } = await import('./js/research-validation.js');
+      return validateDiaryQuality(null);
+    });
+
+    expect(result.warnings[0].type).toBe('EMPTY_DIARY');
+    expect(result.passed).toBe(false);
+  });
+
+  test('fewer than 7 episodes triggers LOW_EPISODE_COUNT', async ({ page }) => {
+    const result = await page.evaluate(async (activities) => {
+      const { validateDiaryQuality } = await import('./js/research-validation.js');
+      return validateDiaryQuality(activities);
+    }, lowEpisodeDiary());
+
+    const lowEp = result.warnings.find(w => w.type === 'LOW_EPISODE_COUNT');
+    expect(lowEp).toBeDefined();
+    expect(lowEp.severity).toBe('moderate');
+    expect(result.episodeCount).toBe(3);
+  });
+
+  test('missing 2+ domains triggers MISSING_DOMAINS', async ({ page }) => {
+    const result = await page.evaluate(async (activities) => {
+      const { validateDiaryQuality } = await import('./js/research-validation.js');
+      return validateDiaryQuality(activities);
+    }, missingDomainsDiary());
+
+    const domainWarn = result.warnings.find(w => w.type === 'MISSING_DOMAINS');
+    expect(domainWarn).toBeDefined();
+    expect(domainWarn.severity).toBe('moderate');
+    expect(result.domainCoverage.missing.length).toBeGreaterThan(1);
+  });
+
+  test('missing only 1 domain does NOT trigger MISSING_DOMAINS', async ({ page }) => {
+    const result = await page.evaluate(async (activities) => {
+      const { validateDiaryQuality } = await import('./js/research-validation.js');
+      return validateDiaryQuality(activities);
+    }, lowEpisodeDiary()); // covers sleep, eating, travel — missing only personalCare
+
+    const domainWarn = result.warnings.find(w => w.type === 'MISSING_DOMAINS');
+    expect(domainWarn).toBeUndefined();
+  });
+
+  test('non-exempt activity over 3 hours triggers LONG_ACTIVITY', async ({ page }) => {
+    const result = await page.evaluate(async (activities) => {
+      const { validateDiaryQuality } = await import('./js/research-validation.js');
+      return validateDiaryQuality(activities);
+    }, longActivityDiary());
+
+    const longWarn = result.warnings.find(w => w.type === 'LONG_ACTIVITY');
+    expect(longWarn).toBeDefined();
+    expect(longWarn.severity).toBe('low');
+    expect(longWarn.activityId).toBe('long-tv');
+    expect(longWarn.message).toContain('Watching TV');
+  });
+
+  test('exempt activities over 3 hours do NOT trigger LONG_ACTIVITY', async ({ page }) => {
+    // Sleeping and Paid Work are both >3h in the good diary but are exempt
+    const result = await page.evaluate(async (activities) => {
+      const { validateDiaryQuality } = await import('./js/research-validation.js');
+      return validateDiaryQuality(activities);
+    }, goodDiary());
+
+    const longWarn = result.warnings.find(w => w.type === 'LONG_ACTIVITY');
+    expect(longWarn).toBeUndefined();
+  });
+
+  test('8+ consecutive identical blocks triggers CONSECUTIVE_IDENTICAL', async ({ page }) => {
+    const result = await page.evaluate(async (activities) => {
+      const { validateDiaryQuality } = await import('./js/research-validation.js');
+      return validateDiaryQuality(activities);
+    }, consecutiveDiary());
+
+    const consWarn = result.warnings.find(w => w.type === 'CONSECUTIVE_IDENTICAL');
+    expect(consWarn).toBeDefined();
+    expect(consWarn.severity).toBe('low');
+    expect(consWarn.message).toContain('10 times in a row');
+    expect(consWarn.message).toContain('Reading');
+  });
+
+  test('7 consecutive identical blocks does NOT trigger warning', async ({ page }) => {
+    const sevenBlocks = Array.from({ length: 7 }, (_, i) =>
+      makeActivity({
+        activity: 'Reading (Including E-books)',
+        startMinutes: 900 + i * 10,
+        endMinutes: 910 + i * 10,
+      })
+    );
+    const diary = [
+      ...goodDiary().slice(0, 5),
+      ...sevenBlocks,
+      makeActivity({ activity: 'Sleeping', startMinutes: 1200, endMinutes: 1440 }),
+    ];
+
+    const result = await page.evaluate(async (activities) => {
+      const { validateDiaryQuality } = await import('./js/research-validation.js');
+      return validateDiaryQuality(activities);
+    }, diary);
+
+    const consWarn = result.warnings.find(w => w.type === 'CONSECUTIVE_IDENTICAL');
+    expect(consWarn).toBeUndefined();
+  });
+
+  test('quality score is clamped between 0 and 100', async ({ page }) => {
+    // Single non-domain activity → many deductions, score should floor at 0
+    const result = await page.evaluate(async () => {
+      const { validateDiaryQuality } = await import('./js/research-validation.js');
+      return validateDiaryQuality([
+        { id: '1', activity: 'Hobbies', category: 'Recreation', startMinutes: 240, endMinutes: 250, startTime: '04:00', endTime: '04:10', color: '#ccc' },
+      ]);
+    });
+
+    expect(result.score).toBeGreaterThanOrEqual(0);
+    expect(result.score).toBeLessThanOrEqual(100);
+  });
+
+  test('consecutive episodes of DIFFERENT activities are counted separately', async ({ page }) => {
+    // 8 blocks alternating between two activities — no consecutive-identical warning
+    const diary = Array.from({ length: 8 }, (_, i) =>
+      makeActivity({
+        activity: i % 2 === 0 ? 'Reading (Including E-books)' : 'Using Computer',
+        startMinutes: 900 + i * 10,
+        endMinutes: 910 + i * 10,
+      })
+    );
+
+    const result = await page.evaluate(async (activities) => {
+      const { validateDiaryQuality } = await import('./js/research-validation.js');
+      return validateDiaryQuality(activities);
+    }, diary);
+
+    const consWarn = result.warnings.find(w => w.type === 'CONSECUTIVE_IDENTICAL');
+    expect(consWarn).toBeUndefined();
+  });
+});
+
+// ===========================================================================
+
+test.describe('Validation Warnings UI — Modal Behaviour', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(UI_TEST_URL);
+    await waitForPageReady(page);
+  });
+
+  test('no warnings → resolves immediately without showing modal', async ({ page }) => {
+    const result = await page.evaluate(async (activities) => {
+      const { showValidationWarnings } = await import('./js/validation-warnings-ui.js');
+      return showValidationWarnings(activities);
+    }, goodDiary());
+
+    expect(result).toBe('submit');
+
+    // Modal should never have appeared
+    const overlay = page.locator('.validation-overlay');
+    await expect(overlay).toHaveCount(0);
+  });
+
+  test('warnings present → modal is shown with correct structure', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    // Overlay
+    const overlay = page.locator('.validation-overlay');
+    await expect(overlay).toBeVisible();
+
+    // Dialog
+    const modal = page.locator('.validation-modal');
+    await expect(modal).toHaveAttribute('role', 'dialog');
+    await expect(modal).toHaveAttribute('aria-modal', 'true');
+
+    // Title
+    await expect(page.locator('#validation-title')).toHaveText('Review Your Diary');
+
+    // Score badge
+    await expect(page.locator('.quality-score')).toBeVisible();
+    await expect(page.locator('.score-value')).toBeVisible();
+
+    // At least one warning
+    const items = page.locator('.warning-item');
+    expect(await items.count()).toBeGreaterThan(0);
+
+    // Buttons
+    await expect(page.locator('#validation-review')).toBeVisible();
+    await expect(page.locator('#validation-submit')).toBeVisible();
+
+    // Footer note
+    await expect(page.locator('.validation-note')).toContainText('suggestions');
+  });
+
+  test('"Submit Anyway" resolves with "submit" and removes modal', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    await page.locator('#validation-submit').click();
+
+    // Wait for exit animation
+    await page.waitForTimeout(300);
+
+    const result = await getValidationResult(page);
+    expect(result).toBe('submit');
+
+    await expect(page.locator('.validation-overlay')).toHaveCount(0);
+  });
+
+  test('"Review My Diary" resolves with "review" and removes modal', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    await page.locator('#validation-review').click();
+    await page.waitForTimeout(300);
+
+    const result = await getValidationResult(page);
+    expect(result).toBe('review');
+
+    await expect(page.locator('.validation-overlay')).toHaveCount(0);
+  });
+
+  test('Escape key resolves with "review"', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(300);
+
+    const result = await getValidationResult(page);
+    expect(result).toBe('review');
+
+    await expect(page.locator('.validation-overlay')).toHaveCount(0);
+  });
+
+  test('clicking outside modal does not close it', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    // Click on overlay (outside modal)
+    await page.locator('.validation-overlay').click({ position: { x: 10, y: 10 } });
+    await page.waitForTimeout(300);
+
+    // Modal should still be visible
+    await expect(page.locator('.validation-modal')).toBeVisible();
+  });
+
+  test('body scroll is locked while modal is open', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    const overflow = await page.evaluate(() => document.body.style.overflow);
+    expect(overflow).toBe('hidden');
+
+    // Close and verify scroll restored
+    await page.locator('#validation-review').click();
+    await page.waitForTimeout(300);
+
+    const overflowAfter = await page.evaluate(() => document.body.style.overflow);
+    expect(overflowAfter).not.toBe('hidden');
+  });
+});
+
+// ===========================================================================
+
+test.describe('Validation Warnings UI — Warning Content', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(UI_TEST_URL);
+    await waitForPageReady(page);
+  });
+
+  test('LOW_EPISODE_COUNT warning displays correct message', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    const warningText = await page.locator('.warning-message').first().textContent();
+    expect(warningText).toContain('3 activities');
+    expect(warningText).toContain('at least 7');
+  });
+
+  test('MISSING_DOMAINS warning lists missing domains', async ({ page }) => {
+    await openValidationModal(page, missingDomainsDiary());
+
+    const warnings = page.locator('.warning-item');
+    const allText = await warnings.allTextContents();
+    const domainWarning = allText.find(t => t.includes("doesn't include"));
+    expect(domainWarning).toBeDefined();
+    // missingDomainsDiary is missing personalCare and travel
+    expect(domainWarning).toContain('personal care');
+    expect(domainWarning).toContain('travel');
+  });
+
+  test('LONG_ACTIVITY warning shows activity name and has "Go to" link', async ({ page }) => {
+    await openValidationModal(page, longActivityDiary());
+
+    const warnings = page.locator('.warning-item');
+    const allText = await warnings.allTextContents();
+    const longWarning = allText.find(t => t.includes('Watching TV'));
+    expect(longWarning).toBeDefined();
+
+    // Should have a "Go to this activity" link for the long activity
+    const goToLink = page.locator('.warning-link[data-activity-id="long-tv"]');
+    await expect(goToLink).toBeVisible();
+    await expect(goToLink).toHaveText('Go to this activity');
+  });
+
+  test('CONSECUTIVE_IDENTICAL warning shows count and duration', async ({ page }) => {
+    await openValidationModal(page, consecutiveDiary());
+
+    const warnings = page.locator('.warning-item');
+    const allText = await warnings.allTextContents();
+    const consWarning = allText.find(t => t.includes('times in a row'));
+    expect(consWarning).toBeDefined();
+    expect(consWarning).toContain('Reading');
+    expect(consWarning).toContain('10 times');
+  });
+
+  test('moderate warnings get moderate styling', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    const moderateItems = page.locator('.warning-item.warning-moderate');
+    expect(await moderateItems.count()).toBeGreaterThan(0);
+  });
+
+  test('low warnings get low styling', async ({ page }) => {
+    await openValidationModal(page, longActivityDiary());
+
+    const lowItems = page.locator('.warning-item.warning-low');
+    expect(await lowItems.count()).toBeGreaterThan(0);
+  });
+
+  test('warning count is stated correctly in intro text', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    const result = await page.evaluate(async (activities) => {
+      const { validateDiaryQuality } = await import('./js/research-validation.js');
+      return validateDiaryQuality(activities);
+    }, lowEpisodeDiary());
+
+    const introText = await page.locator('.validation-intro').textContent();
+    expect(introText).toContain(`${result.warnings.length} thing`);
+  });
+});
+
+// ===========================================================================
+
+test.describe('Validation Warnings UI — Quality Score Display', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(UI_TEST_URL);
+    await waitForPageReady(page);
+  });
+
+  test('score >= 80 shows "good" badge', async ({ page }) => {
+    // longActivityDiary has only 1 low warning → score ~97
+    await openValidationModal(page, longActivityDiary());
+
+    const badge = page.locator('.quality-score');
+    await expect(badge).toHaveClass(/good/);
+  });
+
+  test('score < 60 shows "needs-attention" badge', async ({ page }) => {
+    // missingDomainsDiary has 2 moderate warnings + domain deductions → low score
+    await openValidationModal(page, missingDomainsDiary());
+
+    const badge = page.locator('.quality-score');
+    await expect(badge).toHaveClass(/needs-attention/);
+  });
+
+  test('score badge has accessible label', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    const badge = page.locator('.quality-score');
+    const label = await badge.getAttribute('aria-label');
+    expect(label).toMatch(/Quality score: \d+ out of 100/);
+  });
+
+  test('score value is displayed as a number', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    const scoreText = await page.locator('.score-value').textContent();
+    expect(Number(scoreText)).not.toBeNaN();
+    expect(Number(scoreText)).toBeGreaterThanOrEqual(0);
+    expect(Number(scoreText)).toBeLessThanOrEqual(100);
+  });
+});
+
+// ===========================================================================
+
+test.describe('Validation Warnings UI — Accessibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(UI_TEST_URL);
+    await waitForPageReady(page);
+  });
+
+  test('modal has correct ARIA attributes', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    const modal = page.locator('.validation-modal');
+    await expect(modal).toHaveAttribute('role', 'dialog');
+    await expect(modal).toHaveAttribute('aria-modal', 'true');
+    await expect(modal).toHaveAttribute('aria-labelledby', 'validation-title');
+    await expect(modal).toHaveAttribute('aria-describedby', 'validation-desc');
+  });
+
+  test('overlay has role="presentation"', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    const overlay = page.locator('.validation-overlay');
+    await expect(overlay).toHaveAttribute('role', 'presentation');
+  });
+
+  test('warning icons are hidden from screen readers', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    const icons = page.locator('.warning-icon');
+    const count = await icons.count();
+    for (let i = 0; i < count; i++) {
+      await expect(icons.nth(i)).toHaveAttribute('aria-hidden', 'true');
+    }
+  });
+
+  test('focus moves to Review button on open', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    // Allow initial focus to settle
+    await page.waitForTimeout(200);
+
+    const focusedId = await page.evaluate(() => document.activeElement?.id);
+    expect(focusedId).toBe('validation-review');
+  });
+
+  test('Tab key cycles through focusable elements', async ({ page }) => {
+    await openValidationModal(page, longActivityDiary());
+    await page.waitForTimeout(200);
+
+    // Should start on Review
+    let focusedId = await page.evaluate(() => document.activeElement?.id);
+    expect(focusedId).toBe('validation-review');
+
+    // Tab → should move to "Go to this activity" link (if present) or Submit
+    await page.keyboard.press('Tab');
+    const focusedTag = await page.evaluate(() => document.activeElement?.tagName.toLowerCase());
+    // Either a button.warning-link or #validation-submit
+    expect(['button']).toContain(focusedTag);
+
+    // Keep tabbing until we reach Submit
+    for (let i = 0; i < 5; i++) {
+      focusedId = await page.evaluate(() => document.activeElement?.id);
+      if (focusedId === 'validation-submit') break;
+      await page.keyboard.press('Tab');
+    }
+    focusedId = await page.evaluate(() => document.activeElement?.id);
+    expect(focusedId).toBe('validation-submit');
+
+    // One more Tab should wrap back to Review
+    await page.keyboard.press('Tab');
+    focusedId = await page.evaluate(() => document.activeElement?.id);
+    expect(focusedId).toBe('validation-review');
+  });
+
+  test('Shift+Tab cycles focus backwards', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+    await page.waitForTimeout(200);
+
+    // Starting on Review, Shift+Tab should wrap to Submit
+    await page.keyboard.press('Shift+Tab');
+    const focusedId = await page.evaluate(() => document.activeElement?.id);
+    expect(focusedId).toBe('validation-submit');
+  });
+
+  test('focus is restored to previously focused element after close', async ({ page }) => {
+    // Inject a focusable test anchor so we have a reliable target
+    await page.evaluate(() => {
+      const btn = document.createElement('button');
+      btn.id = 'focus-test-anchor';
+      btn.textContent = 'Test Anchor';
+      document.body.prepend(btn);
+    });
+
+    const anchor = page.locator('#focus-test-anchor');
+    await anchor.focus();
+    await page.waitForTimeout(100);
+
+    await openValidationModal(page, lowEpisodeDiary());
+    await page.locator('#validation-review').click();
+    await page.waitForTimeout(300);
+
+    // Focus should have returned to the test anchor
+    const focusedId = await page.evaluate(() => document.activeElement?.id);
+    expect(focusedId).toBe('focus-test-anchor');
+  });
+
+  test('warnings list uses correct list semantics', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    const list = page.locator('.warnings-list');
+    await expect(list).toHaveAttribute('role', 'list');
+
+    const tagName = await list.evaluate(el => el.tagName.toLowerCase());
+    expect(tagName).toBe('ul');
+
+    const items = page.locator('.warnings-list li.warning-item');
+    await items.first().waitFor({ state: 'attached', timeout: 5000 });
+    expect(await items.count()).toBeGreaterThan(0);
+  });
+});
+
+// ===========================================================================
+
+test.describe('Validation Warnings UI — Activity Highlight', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(UI_TEST_URL);
+    await waitForPageReady(page);
+  });
+
+  test('"Go to this activity" link closes modal and highlights block', async ({ page }) => {
+    // Place an activity on the timeline so there's a real DOM block to find
+    const activityId = 'highlight-test-id';
+
+    // Inject a mock activity block into the timeline DOM
+    await page.evaluate((id) => {
+      const block = document.createElement('div');
+      block.className = 'activity-block';
+      block.dataset.id = id;
+      block.style.cssText = 'position: absolute; width: 50px; height: 20px; top: 200px; left: 100px;';
+      block.textContent = 'Test Activity';
+      const timeline = document.querySelector('.timeline-column') || document.body;
+      timeline.appendChild(block);
+    }, activityId);
+
+    // Create a diary with a long activity that references our mock block
+    const diary = longActivityDiary().map(a =>
+      a.id === 'long-tv' ? { ...a, id: activityId } : a
+    );
+
+    await openValidationModal(page, diary);
+
+    const goToLink = page.locator(`.warning-link[data-activity-id="${activityId}"]`);
+    await expect(goToLink).toBeVisible();
+    await goToLink.click();
+
+    // Wait for modal exit + highlight delay
+    await page.waitForTimeout(600);
+
+    // Modal should be gone
+    await expect(page.locator('.validation-overlay')).toHaveCount(0);
+
+    // Block should have the highlight class
+    const block = page.locator(`.activity-block[data-id="${activityId}"]`);
+    await expect(block).toHaveClass(/highlight-pulse/);
+  });
+
+  test('highlight-pulse class is removed after 2 seconds', async ({ page }) => {
+    const activityId = 'pulse-timeout-test';
+
+    await page.evaluate((id) => {
+      const block = document.createElement('div');
+      block.className = 'activity-block';
+      block.dataset.id = id;
+      block.style.cssText = 'position: absolute; width: 50px; height: 20px;';
+      (document.querySelector('.timeline-column') || document.body).appendChild(block);
+    }, activityId);
+
+    const diary = longActivityDiary().map(a =>
+      a.id === 'long-tv' ? { ...a, id: activityId } : a
+    );
+
+    await openValidationModal(page, diary);
+    await page.locator(`.warning-link[data-activity-id="${activityId}"]`).click();
+
+    // Wait for highlight to appear
+    await page.waitForTimeout(600);
+    await expect(page.locator(`.activity-block[data-id="${activityId}"]`)).toHaveClass(/highlight-pulse/);
+
+    // Wait for highlight to be removed (2s timeout + buffer)
+    await page.waitForTimeout(2000);
+    const block = page.locator(`.activity-block[data-id="${activityId}"]`);
+    await expect(block).not.toHaveClass(/highlight-pulse/);
+  });
+});
+
+// ===========================================================================
+
+test.describe('Validation Warnings UI — Entrance/Exit Animations', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(UI_TEST_URL);
+    await waitForPageReady(page);
+  });
+
+  test('overlay gains "visible" class on open', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    const overlay = page.locator('.validation-overlay');
+    await expect(overlay).toHaveClass(/visible/);
+  });
+
+  test('overlay gains "closing" class before removal', async ({ page }) => {
+    await openValidationModal(page, lowEpisodeDiary());
+
+    // Click submit — triggers closing animation
+    await page.locator('#validation-submit').click();
+
+    // Immediately check for closing class (before the 200ms removal)
+    const overlay = page.locator('.validation-overlay');
+    await expect(overlay).toHaveClass(/closing/);
+  });
+});

--- a/js/research-validation.js
+++ b/js/research-validation.js
@@ -1,0 +1,278 @@
+/**
+ * Research-grade validation for time use diaries
+ * Based on CTUR/HETUS data quality standards
+ *
+ * These are SOFT warnings — they inform participants but never block submission.
+ * References:
+ *   - MTUS "good quality" diary criteria (minimum 7 episodes)
+ *   - HETUS basic domain coverage (sleep, personal care, eating, travel)
+ *   - CTUR suspicious-duration heuristics (>3h non-exempt, 8+ identical slots)
+ */
+
+import { INCREMENT_MINUTES } from './constants.js';
+
+// ---------------------------------------------------------------------------
+// Domain keywords mapped to actual O-TUD activity names from activities.json
+// ---------------------------------------------------------------------------
+const BASIC_DOMAINS = {
+  sleep: ['sleeping', 'resting', 'rest', 'nap', 'sick in bed'],
+  personalCare: ['washing', 'dressing', 'personal care', 'grooming'],
+  eating: [
+    'eating', 'drinking', 'meal', 'breakfast', 'lunch', 'dinner',
+    'going out to eat', 'food preparation', 'cooking'
+  ],
+  travel: ['travelling', 'travel', 'commute', 'transport', 'driving', 'walking/jogging', 'cycle']
+};
+
+// Activities that legitimately span 3+ hours — matched case-insensitively
+const LONG_ACTIVITY_EXCEPTIONS = [
+  'sleeping', 'paid work', 'paid job', 'formal education',
+  'classes and lectures', 'homework', 'school', 'internship',
+  'work/study break'
+];
+
+const MIN_EPISODES = 7;
+const LONG_ACTIVITY_THRESHOLD = 180; // 3 hours in minutes
+const CONSECUTIVE_IDENTICAL_THRESHOLD = 8; // 8 × 10-min slots = 80 minutes
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate diary against research quality standards.
+ * @param {Array} activities - Placed activities from timelineManager.activities[key].
+ *   Each object has: { id, activity, category, startMinutes, endMinutes, … }
+ * @returns {{ score: number, warnings: Array, passed: boolean, episodeCount: number, domainCoverage: Object }}
+ */
+export function validateDiaryQuality(activities) {
+  if (!activities || activities.length === 0) {
+    return {
+      score: 0,
+      warnings: [{
+        type: 'EMPTY_DIARY',
+        severity: 'moderate',
+        message: 'Your diary is empty.',
+        suggestion: 'Please add your daily activities to the timeline.'
+      }],
+      passed: false,
+      episodeCount: 0,
+      domainCoverage: { covered: [], missing: Object.keys(BASIC_DOMAINS).map(formatDomainName) }
+    };
+  }
+
+  const warnings = [];
+
+  // 1. Episode count (MTUS minimum-7 rule)
+  const episodeCount = countEpisodes(activities);
+  if (episodeCount < MIN_EPISODES) {
+    warnings.push({
+      type: 'LOW_EPISODE_COUNT',
+      severity: 'moderate',
+      message: `Your diary has ${episodeCount} activities. Most people have at least ${MIN_EPISODES} distinct activities in a day.`,
+      suggestion: 'Consider if you might have forgotten any activities or transitions.'
+    });
+  }
+
+  // 2. Basic domain coverage (HETUS 3-of-4 rule)
+  const domainCoverage = checkDomainCoverage(activities);
+  if (domainCoverage.missing.length > 1) {
+    warnings.push({
+      type: 'MISSING_DOMAINS',
+      severity: 'moderate',
+      message: `Your diary doesn't include: ${domainCoverage.missing.join(', ')}.`,
+      suggestion: 'Most days include sleep, personal care, eating, and some travel. Did you forget to log any of these?'
+    });
+  }
+
+  // 3. Unusually long activities (CTUR >3h heuristic)
+  const longActivities = findLongActivities(activities);
+  longActivities.forEach(act => {
+    warnings.push({
+      type: 'LONG_ACTIVITY',
+      severity: 'low',
+      message: `"${act.name}" is logged for ${formatDuration(act.duration)}.`,
+      suggestion: 'If this is correct, no action needed. If not, consider breaking it into smaller segments.',
+      activityId: act.id
+    });
+  });
+
+  // 4. Consecutive identical slots (poor-recall indicator)
+  const consecutiveIssues = findConsecutiveIdentical(activities);
+  consecutiveIssues.forEach(issue => {
+    warnings.push({
+      type: 'CONSECUTIVE_IDENTICAL',
+      severity: 'low',
+      message: `"${issue.name}" appears ${issue.count} times in a row (${formatDuration(issue.duration)}).`,
+      suggestion: 'Did anything else happen during this time? Consider if there were any breaks or transitions.'
+    });
+  });
+
+  const score = calculateQualityScore(episodeCount, domainCoverage, warnings);
+
+  return {
+    score,
+    warnings,
+    passed: warnings.filter(w => w.severity === 'moderate').length === 0,
+    episodeCount,
+    domainCoverage
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Count distinct episodes — consecutive blocks with the same activity name
+ * are collapsed into one episode.
+ */
+function countEpisodes(activities) {
+  const sorted = [...activities].sort((a, b) => a.startMinutes - b.startMinutes);
+
+  let count = 0;
+  let lastActivity = null;
+
+  sorted.forEach(act => {
+    if (act.activity !== lastActivity) {
+      count++;
+      lastActivity = act.activity;
+    }
+  });
+
+  return count;
+}
+
+/**
+ * Check which of the four basic daily domains are represented.
+ */
+function checkDomainCoverage(activities) {
+  const activityNames = activities.map(a => a.activity.toLowerCase());
+  const covered = [];
+  const missing = [];
+
+  Object.entries(BASIC_DOMAINS).forEach(([domain, keywords]) => {
+    const found = activityNames.some(name =>
+      keywords.some(keyword => name.includes(keyword))
+    );
+
+    if (found) {
+      covered.push(domain);
+    } else {
+      missing.push(formatDomainName(domain));
+    }
+  });
+
+  return { covered, missing };
+}
+
+/**
+ * Find activities that exceed the 3-hour threshold (excluding exempted ones).
+ */
+function findLongActivities(activities) {
+  return activities
+    .filter(a => {
+      const duration = getDurationMinutes(a);
+      const isException = LONG_ACTIVITY_EXCEPTIONS.some(ex =>
+        a.activity.toLowerCase().includes(ex)
+      );
+      return duration > LONG_ACTIVITY_THRESHOLD && !isException;
+    })
+    .map(a => ({
+      id: a.id,
+      name: a.activity,
+      duration: getDurationMinutes(a)
+    }));
+}
+
+/**
+ * Detect sequences of adjacent identical activities.
+ *
+ * Two blocks are "consecutive" when one ends where the next begins
+ * (within one INCREMENT_MINUTES tolerance to allow for grid-snap gaps).
+ * A sequence of N blocks maps to N 10-minute slots; flag when N >= threshold.
+ */
+function findConsecutiveIdentical(activities) {
+  if (activities.length < 2) return [];
+
+  const sorted = [...activities].sort((a, b) => a.startMinutes - b.startMinutes);
+  const issues = [];
+
+  let runStart = 0;
+
+  for (let i = 1; i <= sorted.length; i++) {
+    const prev = sorted[i - 1];
+    const curr = sorted[i];
+
+    // Continue the run if same activity and temporally adjacent
+    const sameRun = curr &&
+      curr.activity === prev.activity &&
+      Math.abs(curr.startMinutes - prev.endMinutes) <= INCREMENT_MINUTES;
+
+    if (!sameRun) {
+      // End of a run — check if it is long enough to flag
+      const runLength = i - runStart;
+      if (runLength >= CONSECUTIVE_IDENTICAL_THRESHOLD) {
+        const first = sorted[runStart];
+        const last = sorted[i - 1];
+        issues.push({
+          name: first.activity,
+          count: runLength,
+          duration: last.endMinutes - first.startMinutes
+        });
+      }
+      runStart = i;
+    }
+  }
+
+  return issues;
+}
+
+/**
+ * Produce a 0-100 quality score from the collected signals.
+ */
+function calculateQualityScore(episodeCount, domainCoverage, warnings) {
+  let score = 100;
+
+  // Deduct for low episode count
+  if (episodeCount < MIN_EPISODES) {
+    score -= (MIN_EPISODES - episodeCount) * 5;
+  }
+
+  // Deduct for missing basic domains
+  score -= domainCoverage.missing.length * 10;
+
+  // Deduct per warning by severity
+  warnings.forEach(w => {
+    if (w.severity === 'moderate') score -= 10;
+    if (w.severity === 'low') score -= 3;
+  });
+
+  return Math.max(0, Math.min(100, score));
+}
+
+// ---------------------------------------------------------------------------
+// Utility helpers
+// ---------------------------------------------------------------------------
+
+function getDurationMinutes(activity) {
+  return activity.endMinutes - activity.startMinutes;
+}
+
+function formatDuration(minutes) {
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  if (hours === 0) return `${mins} minutes`;
+  if (mins === 0) return `${hours} hour${hours > 1 ? 's' : ''}`;
+  return `${hours}h ${mins}m`;
+}
+
+function formatDomainName(domain) {
+  const names = {
+    sleep: 'sleep or rest',
+    personalCare: 'personal care',
+    eating: 'eating or drinking',
+    travel: 'travel or transport'
+  };
+  return names[domain] || domain;
+}

--- a/js/validation-warnings-ui.js
+++ b/js/validation-warnings-ui.js
@@ -1,0 +1,219 @@
+/**
+ * UI for research validation warnings
+ * Follows the recovery-modal.js pattern: overlay + inner dialog, focus trap,
+ * entrance/exit animations, body-scroll lock, full keyboard + screen-reader support.
+ */
+
+import { validateDiaryQuality } from './research-validation.js';
+
+/**
+ * Show validation warnings panel before submission.
+ * Resolves immediately with 'submit' when there are no warnings.
+ * @param {Array} activities - Activities from timelineManager.activities[key]
+ * @returns {Promise<'submit'|'review'>} User's choice
+ */
+export function showValidationWarnings(activities) {
+  const validation = validateDiaryQuality(activities);
+
+  if (validation.warnings.length === 0) {
+    return Promise.resolve('submit');
+  }
+
+  return new Promise((resolve) => {
+    const previouslyFocused = document.activeElement;
+    const overlay = createWarningsOverlay(validation, resolve, previouslyFocused);
+    document.body.appendChild(overlay);
+
+    // Trigger entrance animation on next frame
+    requestAnimationFrame(() => {
+      overlay.classList.add('visible');
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// DOM construction
+// ---------------------------------------------------------------------------
+
+function createWarningsOverlay(validation, resolve, previouslyFocused) {
+  const overlay = document.createElement('div');
+  overlay.className = 'validation-overlay';
+  overlay.setAttribute('role', 'presentation');
+
+  const modal = document.createElement('div');
+  modal.className = 'validation-modal';
+  modal.setAttribute('role', 'dialog');
+  modal.setAttribute('aria-modal', 'true');
+  modal.setAttribute('aria-labelledby', 'validation-title');
+  modal.setAttribute('aria-describedby', 'validation-desc');
+  modal.setAttribute('tabindex', '-1');
+
+  const scoreClass =
+    validation.score >= 80 ? 'good' : validation.score >= 60 ? 'fair' : 'needs-attention';
+
+  const warningCount = validation.warnings.length;
+
+  modal.innerHTML = `
+    <header class="validation-header">
+      <h2 id="validation-title">Review Your Diary</h2>
+      <div class="quality-score ${scoreClass}" role="status" aria-label="Quality score: ${validation.score} out of 100">
+        <span class="score-value">${validation.score}</span>
+        <span class="score-label">Quality Score</span>
+      </div>
+    </header>
+
+    <div class="validation-body">
+      <p id="validation-desc" class="validation-intro">
+        We found ${warningCount} thing${warningCount > 1 ? 's' : ''} you might want to review:
+      </p>
+
+      <ul class="warnings-list" role="list">
+        ${validation.warnings.map(warning => `
+          <li class="warning-item warning-${warning.severity}">
+            <span class="warning-icon" aria-hidden="true">
+              ${warning.severity === 'moderate'
+                ? '<svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M10 2L1 18h18L10 2z" stroke="currentColor" stroke-width="1.5" fill="none"/><path d="M10 8v4M10 14h.01" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>'
+                : '<svg width="20" height="20" viewBox="0 0 20 20" fill="none"><circle cx="10" cy="10" r="8" stroke="currentColor" stroke-width="1.5"/><path d="M10 9v4M10 7h.01" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>'
+              }
+            </span>
+            <div class="warning-content">
+              <p class="warning-message">${escapeHtml(warning.message)}</p>
+              <p class="warning-suggestion">${escapeHtml(warning.suggestion)}</p>
+              ${warning.activityId ? `
+                <button type="button" class="warning-link" data-activity-id="${escapeHtml(warning.activityId)}">
+                  Go to this activity
+                </button>
+              ` : ''}
+            </div>
+          </li>
+        `).join('')}
+      </ul>
+    </div>
+
+    <footer class="validation-footer">
+      <p class="validation-note">
+        These are suggestions to help improve data quality. You can still submit if everything looks correct.
+      </p>
+      <div class="validation-actions">
+        <button type="button" class="btn btn-secondary" id="validation-review">
+          Review My Diary
+        </button>
+        <button type="button" class="btn btn-primary" id="validation-submit">
+          Submit Anyway
+        </button>
+      </div>
+    </footer>
+  `;
+
+  overlay.appendChild(modal);
+
+  // ---------------------------------------------------------------------------
+  // Focus management
+  // ---------------------------------------------------------------------------
+  const originalOverflow = document.body.style.overflow;
+  document.body.style.overflow = 'hidden';
+
+  const submitBtn = modal.querySelector('#validation-submit');
+  const reviewBtn = modal.querySelector('#validation-review');
+  const activityLinks = Array.from(modal.querySelectorAll('.warning-link'));
+  const focusableElements = [reviewBtn, ...activityLinks, submitBtn];
+  let currentFocusIndex = 0;
+
+  // Announce to screen reader then move focus to first button
+  modal.focus();
+  setTimeout(() => {
+    reviewBtn.focus();
+  }, 50);
+
+  // ---------------------------------------------------------------------------
+  // Cleanup helper
+  // ---------------------------------------------------------------------------
+  const cleanup = (result) => {
+    document.removeEventListener('keydown', handleKeydown);
+    overlay.classList.add('closing');
+
+    setTimeout(() => {
+      document.body.style.overflow = originalOverflow;
+      if (overlay.parentNode) {
+        overlay.parentNode.removeChild(overlay);
+      }
+      if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+        previouslyFocused.focus();
+      }
+      resolve(result);
+    }, 200);
+  };
+
+  // ---------------------------------------------------------------------------
+  // Event handlers
+  // ---------------------------------------------------------------------------
+  submitBtn.addEventListener('click', () => cleanup('submit'));
+  reviewBtn.addEventListener('click', () => cleanup('review'));
+
+  // Activity "go-to" links
+  activityLinks.forEach(link => {
+    link.addEventListener('click', () => {
+      const activityId = link.dataset.activityId;
+      cleanup('review');
+      // Wait for modal exit animation before scrolling
+      setTimeout(() => highlightActivity(activityId), 250);
+    });
+  });
+
+  // Click outside modal → redirect focus (don't dismiss)
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) {
+      reviewBtn.focus();
+      currentFocusIndex = 0;
+    }
+  });
+
+  /** @param {KeyboardEvent} e */
+  const handleKeydown = (e) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      cleanup('review');
+      return;
+    }
+
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      if (e.shiftKey) {
+        currentFocusIndex =
+          (currentFocusIndex - 1 + focusableElements.length) % focusableElements.length;
+      } else {
+        currentFocusIndex = (currentFocusIndex + 1) % focusableElements.length;
+      }
+      focusableElements[currentFocusIndex].focus();
+    }
+  };
+
+  document.addEventListener('keydown', handleKeydown);
+
+  return overlay;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Scroll to and visually highlight an activity block on the timeline.
+ */
+function highlightActivity(activityId) {
+  const block = document.querySelector(`.activity-block[data-id="${activityId}"]`);
+  if (!block) return;
+
+  block.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  block.classList.add('highlight-pulse');
+  setTimeout(() => block.classList.remove('highlight-pulse'), 2000);
+}
+
+/**
+ * Basic HTML-entity escaping to prevent injection from activity names.
+ */
+function escapeHtml(str) {
+  const div = document.createElement('div');
+  div.textContent = str;
+  return div.innerHTML;
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -2534,3 +2534,475 @@ body {
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
     }
 }
+
+/* ==========================================================================
+   Validation Warnings Modal
+   Research-grade diary quality feedback — WCAG 2.1 AA compliant
+   ========================================================================== */
+
+.validation-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10000;
+    padding: 20px;
+    transition: background-color 0.2s ease-out;
+}
+
+.validation-overlay.visible {
+    background: rgba(0, 0, 0, 0.6);
+}
+
+.validation-overlay.closing {
+    background: rgba(0, 0, 0, 0);
+}
+
+.validation-modal {
+    background: #fff;
+    border-radius: 12px;
+    max-width: 500px;
+    width: 100%;
+    max-height: 80vh;
+    overflow-y: auto;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+    transform: translateY(20px) scale(0.95);
+    opacity: 0;
+    transition: transform 0.25s ease-out, opacity 0.25s ease-out;
+}
+
+.validation-overlay.visible .validation-modal {
+    transform: translateY(0) scale(1);
+    opacity: 1;
+}
+
+.validation-overlay.closing .validation-modal {
+    transform: translateY(-10px) scale(0.95);
+    opacity: 0;
+}
+
+.validation-modal:focus {
+    outline: none;
+}
+
+/* Header */
+.validation-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: clamp(16px, 4vw, 20px) clamp(16px, 4vw, 24px);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.validation-header h2 {
+    margin: 0;
+    font-size: clamp(1.1rem, 4vw, 1.25rem);
+    color: var(--text-color);
+    font-weight: 600;
+}
+
+/* Quality score badge */
+.quality-score {
+    text-align: center;
+    padding: 8px 16px;
+    border-radius: 8px;
+    flex-shrink: 0;
+}
+
+.quality-score.good {
+    background: #d1fae5;
+    color: #065f46;
+}
+
+.quality-score.fair {
+    background: #fef3c7;
+    color: #92400e;
+}
+
+.quality-score.needs-attention {
+    background: #fee2e2;
+    color: #991b1b;
+}
+
+.score-value {
+    display: block;
+    font-size: 1.5rem;
+    font-weight: 700;
+    line-height: 1;
+}
+
+.score-label {
+    display: block;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-top: 2px;
+}
+
+/* Body / warnings list */
+.validation-body {
+    padding: clamp(16px, 4vw, 20px) clamp(16px, 4vw, 24px);
+}
+
+.validation-intro {
+    margin: 0 0 16px 0;
+    color: var(--secondary-color);
+    font-size: clamp(0.875rem, 3.5vw, 1rem);
+    line-height: 1.5;
+}
+
+.warnings-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.warning-item {
+    display: flex;
+    gap: 12px;
+    padding: 12px;
+    margin-bottom: 12px;
+    border-radius: 8px;
+    background: var(--background-color);
+}
+
+.warning-item:last-child {
+    margin-bottom: 0;
+}
+
+.warning-item.warning-moderate {
+    background: #fef3c7;
+}
+
+.warning-icon {
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    margin-top: 2px;
+    color: var(--secondary-color);
+}
+
+.warning-moderate .warning-icon {
+    color: #92400e;
+}
+
+.warning-message {
+    margin: 0 0 4px 0;
+    font-size: clamp(0.875rem, 3.5vw, 0.9375rem);
+    font-weight: 500;
+    color: var(--text-color);
+    line-height: 1.4;
+}
+
+.warning-suggestion {
+    margin: 0;
+    font-size: clamp(0.8rem, 3vw, 0.875rem);
+    color: var(--secondary-color);
+    line-height: 1.4;
+}
+
+.warning-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 8px;
+    padding: 4px 10px;
+    font-size: 0.8125rem;
+    font-family: inherit;
+    background: none;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    cursor: pointer;
+    color: var(--primary-color);
+    transition: background-color 0.15s;
+}
+
+.warning-link:hover {
+    background: var(--background-color);
+}
+
+.warning-link:focus {
+    outline: 2px solid var(--primary-color);
+    outline-offset: 2px;
+}
+
+/* Footer */
+.validation-footer {
+    padding: clamp(12px, 3vw, 16px) clamp(16px, 4vw, 24px);
+    border-top: 1px solid var(--border-color);
+    background: var(--background-color);
+    border-radius: 0 0 12px 12px;
+}
+
+.validation-note {
+    margin: 0 0 16px 0;
+    font-size: clamp(0.8rem, 3vw, 0.875rem);
+    color: var(--secondary-color);
+    line-height: 1.4;
+}
+
+.validation-actions {
+    display: flex;
+    gap: 12px;
+    flex-direction: column;
+}
+
+.validation-modal .btn {
+    flex: 1;
+    padding: 12px 20px;
+    border-radius: 8px;
+    border: none;
+    font-size: clamp(0.875rem, 3.5vw, 1rem);
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    text-align: center;
+    transition: background-color 0.15s, transform 0.1s;
+    min-height: 48px;
+}
+
+.validation-modal .btn:focus {
+    outline: 3px solid var(--primary-color);
+    outline-offset: 2px;
+}
+
+.validation-modal .btn-primary {
+    background: var(--primary-color);
+    color: #fff;
+}
+
+.validation-modal .btn-primary:hover {
+    background: #1d4ed8;
+    transform: translateY(-1px);
+}
+
+.validation-modal .btn-primary:active {
+    background: #1e40af;
+    transform: translateY(0);
+}
+
+.validation-modal .btn-secondary {
+    background: #f1f5f9;
+    color: var(--text-color);
+}
+
+.validation-modal .btn-secondary:hover {
+    background: #e2e8f0;
+}
+
+.validation-modal .btn-secondary:active {
+    background: #cbd5e1;
+}
+
+/* Desktop: side-by-side buttons */
+@media (min-width: 480px) {
+    .validation-actions {
+        flex-direction: row;
+    }
+}
+
+/* Activity highlight animation */
+@keyframes highlight-pulse {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(37, 99, 235, 0.4); }
+    50% { box-shadow: 0 0 0 8px rgba(37, 99, 235, 0); }
+}
+
+.highlight-pulse {
+    animation: highlight-pulse 1s ease-in-out 2;
+}
+
+/* High contrast mode */
+@media (prefers-contrast: more) {
+    .validation-modal {
+        border: 3px solid var(--text-color);
+    }
+
+    .warning-item {
+        border: 1px solid var(--text-color);
+    }
+
+    .warning-item.warning-moderate {
+        border-width: 2px;
+    }
+
+    .quality-score {
+        border: 2px solid currentColor;
+    }
+
+    .validation-modal .btn {
+        border: 2px solid currentColor;
+    }
+
+    .validation-modal .btn:focus {
+        outline-width: 4px;
+    }
+
+    .warning-link {
+        border-width: 2px;
+    }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    .validation-overlay,
+    .validation-modal,
+    .validation-modal .btn,
+    .warning-link {
+        transition: none;
+    }
+
+    .validation-overlay.visible .validation-modal {
+        transform: none;
+    }
+
+    .validation-modal .btn-primary:hover {
+        transform: none;
+    }
+
+    .highlight-pulse {
+        animation: none;
+        outline: 3px solid var(--primary-color);
+    }
+}
+
+/* Dark mode */
+@media (prefers-color-scheme: dark) {
+    .validation-modal {
+        background: #1e293b;
+        box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+    }
+
+    .validation-header {
+        border-bottom-color: #334155;
+    }
+
+    .validation-header h2 {
+        color: #f1f5f9;
+    }
+
+    .quality-score.good {
+        background: #064e3b;
+        color: #6ee7b7;
+    }
+
+    .quality-score.fair {
+        background: #78350f;
+        color: #fcd34d;
+    }
+
+    .quality-score.needs-attention {
+        background: #7f1d1d;
+        color: #fca5a5;
+    }
+
+    .validation-intro,
+    .validation-note,
+    .warning-suggestion {
+        color: #94a3b8;
+    }
+
+    .warning-message {
+        color: #f1f5f9;
+    }
+
+    .warning-item {
+        background: #334155;
+    }
+
+    .warning-item.warning-moderate {
+        background: #451a03;
+    }
+
+    .warning-icon {
+        color: #94a3b8;
+    }
+
+    .warning-moderate .warning-icon {
+        color: #fbbf24;
+    }
+
+    .warning-link {
+        border-color: #475569;
+        color: #60a5fa;
+    }
+
+    .warning-link:hover {
+        background: #475569;
+    }
+
+    .validation-footer {
+        background: #1e293b;
+        border-top-color: #334155;
+    }
+
+    .validation-modal .btn-secondary {
+        background: #334155;
+        color: #f1f5f9;
+    }
+
+    .validation-modal .btn-secondary:hover {
+        background: #475569;
+    }
+
+    .validation-modal .btn-secondary:active {
+        background: #1e293b;
+    }
+}
+
+/* Landscape orientation on mobile */
+@media (orientation: landscape) and (max-height: 500px) {
+    .validation-modal {
+        max-height: 90vh;
+    }
+
+    .validation-header {
+        padding: 12px 16px;
+    }
+
+    .validation-header h2 {
+        font-size: 1rem;
+    }
+
+    .score-value {
+        font-size: 1.25rem;
+    }
+
+    .validation-body {
+        padding: 12px 16px;
+    }
+
+    .warning-item {
+        padding: 8px;
+        margin-bottom: 8px;
+    }
+
+    .validation-footer {
+        padding: 12px 16px;
+    }
+
+    .validation-note {
+        margin-bottom: 12px;
+    }
+
+    .validation-actions {
+        flex-direction: row;
+    }
+
+    .validation-modal .btn {
+        padding: 10px 16px;
+        min-height: 40px;
+    }
+}
+
+/* Small screens */
+@media (max-width: 480px) {
+    .validation-overlay {
+        padding: 12px;
+    }
+
+    .validation-modal {
+        max-height: 85vh;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds soft validation warnings based on CTUR/HETUS time use research standards to help participants improve diary quality before submission
- Warnings are informational only and never block submission
- Includes an accessible modal dialog that displays a quality score and actionable suggestions

## What it does

The validation checks four research quality indicators:

1. **Episode count** — flags diaries with fewer than 7 distinct activities, which the MTUS considers the minimum for a good-quality diary
2. **Domain coverage** — checks whether the diary includes activities from at least 3 of 4 basic daily domains: sleep/rest, personal care, eating/drinking, and travel
3. **Suspicious durations** — identifies non-exempt activities logged for more than 3 hours (sleep, work, and education are excluded from this check)
4. **Consecutive identical entries** — detects 8 or more adjacent identical 10-minute blocks, which typically indicates poor recall rather than genuine activity

## How it works

When a participant is about to submit, `showValidationWarnings()` runs the checks against their placed activities. If there are no issues, submission proceeds immediately. If warnings are found, a modal appears showing:

- A quality score (0–100) with a colour-coded badge (good, fair, needs attention)
- Each warning with its severity level, a plain-language message, and a suggestion
- A "Go to this activity" link for duration warnings that scrolls to and highlights the relevant block on the timeline
- Two actions: "Review My Diary" (go back and edit) or "Submit Anyway" (proceed with submission)

## New files

- `js/research-validation.js` — validation logic with domain keyword matching tuned to the actual activity names in `activities.json`
- `js/validation-warnings-ui.js` — modal dialog following the same patterns as `recovery-modal.js` (focus trap, body scroll lock, entrance/exit animations, Escape key handling)
- `styles/styles.css` — modal styles with support for `prefers-reduced-motion`, `prefers-contrast`, dark mode, and mobile/landscape breakpoints

## Accessibility

- `role="dialog"` with `aria-modal`, `aria-labelledby`, and `aria-describedby`
- Focus trap with Tab/Shift+Tab cycling
- Focus restored to the previously focused element on close
- Quality score badge has an `aria-label` describing the score
- Warning icons are `aria-hidden`
- All buttons meet 48px minimum touch target size
- Highlight animation falls back to a solid outline when reduced motion is preferred